### PR TITLE
Added init task to clean workspace

### DIFF
--- a/labs/04_unit_test_automation/pipeline.yaml
+++ b/labs/04_unit_test_automation/pipeline.yaml
@@ -10,6 +10,13 @@ spec:
     - name: branch
       default: master
   tasks:
+    - name: init
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace          
+      taskRef:
+        name: cleanup
+
     - name: clone
       workspaces:
         - name: output
@@ -21,6 +28,8 @@ spec:
         value: $(params.repo-url)
       - name: revision
         value: $(params.branch)
+      runAfter:
+        - init      
 
     - name: lint
       taskRef:

--- a/labs/04_unit_test_automation/tasks.yaml
+++ b/labs/04_unit_test_automation/tasks.yaml
@@ -12,3 +12,40 @@ spec:
       image: alpine:3
       command: [/bin/echo]
       args: ["$(params.message)"]
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: cleanup
+spec:
+  description: This task will clean up a workspace by deleting all of the files.
+  workspaces:
+    - name: source
+  steps:
+    - name: remove
+      image: alpine:3
+      env:
+        - name: WORKSPACE_SOURCE_PATH
+          value: $(workspaces.source.path)
+      workingDir: $(workspaces.source.path)
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+        echo "Removing all files from ${WORKSPACE_SOURCE_PATH} ..."
+        # Delete any existing contents of the directory if it exists.
+        #
+        # We don't just "rm -rf ${WORKSPACE_SOURCE_PATH}" because ${WORKSPACE_SOURCE_PATH} might be "/"
+        # or the root of a mounted volume.
+        if [ -d "${WORKSPACE_SOURCE_PATH}" ] ; then
+          # Delete non-hidden files and directories
+          rm -rf "${WORKSPACE_SOURCE_PATH:?}"/*
+          # Delete files and directories starting with . but excluding ..
+          rm -rf "${WORKSPACE_SOURCE_PATH}"/.[!.]*
+          # Delete files and directories starting with .. plus any other character
+          rm -rf "${WORKSPACE_SOURCE_PATH}"/..?*
+        fi
+

--- a/labs/05_build_an_image/pipeline.yaml
+++ b/labs/05_build_an_image/pipeline.yaml
@@ -10,6 +10,13 @@ spec:
     - name: branch
       default: master
   tasks:
+    - name: init
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace          
+      taskRef:
+        name: cleanup
+
     - name: clone
       workspaces:
         - name: output
@@ -21,6 +28,8 @@ spec:
         value: $(params.repo-url)
       - name: revision
         value: $(params.branch)
+      runAfter:
+        - init      
 
     - name: lint
       workspaces:

--- a/labs/05_build_an_image/tasks.yaml
+++ b/labs/05_build_an_image/tasks.yaml
@@ -12,6 +12,43 @@ spec:
       image: alpine:3
       command: [/bin/echo]
       args: ["$(params.message)"]
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: cleanup
+spec:
+  description: This task will clean up a workspace by deleting all of the files.
+  workspaces:
+    - name: source
+  steps:
+    - name: remove
+      image: alpine:3
+      env:
+        - name: WORKSPACE_SOURCE_PATH
+          value: $(workspaces.source.path)
+      workingDir: $(workspaces.source.path)
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+        echo "Removing all files from ${WORKSPACE_SOURCE_PATH} ..."
+        # Delete any existing contents of the directory if it exists.
+        #
+        # We don't just "rm -rf ${WORKSPACE_SOURCE_PATH}" because ${WORKSPACE_SOURCE_PATH} might be "/"
+        # or the root of a mounted volume.
+        if [ -d "${WORKSPACE_SOURCE_PATH}" ] ; then
+          # Delete non-hidden files and directories
+          rm -rf "${WORKSPACE_SOURCE_PATH:?}"/*
+          # Delete files and directories starting with . but excluding ..
+          rm -rf "${WORKSPACE_SOURCE_PATH}"/.[!.]*
+          # Delete files and directories starting with .. plus any other character
+          rm -rf "${WORKSPACE_SOURCE_PATH}"/..?*
+        fi
+
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task

--- a/labs/06_deploy_to_kubernetes/pipeline.yaml
+++ b/labs/06_deploy_to_kubernetes/pipeline.yaml
@@ -11,6 +11,13 @@ spec:
     - name: branch
       default: master
   tasks:
+    - name: init
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace          
+      taskRef:
+        name: cleanup
+
     - name: clone
       workspaces:
         - name: output
@@ -22,6 +29,8 @@ spec:
         value: $(params.repo-url)
       - name: revision
         value: $(params.branch)
+      runAfter:
+        - init      
 
     - name: lint
       workspaces:

--- a/labs/06_deploy_to_kubernetes/tasks.yaml
+++ b/labs/06_deploy_to_kubernetes/tasks.yaml
@@ -12,6 +12,43 @@ spec:
       image: alpine:3
       command: [/bin/echo]
       args: ["$(params.message)"]
+
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: cleanup
+spec:
+  description: This task will clean up a workspace by deleting all of the files.
+  workspaces:
+    - name: source
+  steps:
+    - name: remove
+      image: alpine:3
+      env:
+        - name: WORKSPACE_SOURCE_PATH
+          value: $(workspaces.source.path)
+      workingDir: $(workspaces.source.path)
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+        echo "Removing all files from ${WORKSPACE_SOURCE_PATH} ..."
+        # Delete any existing contents of the directory if it exists.
+        #
+        # We don't just "rm -rf ${WORKSPACE_SOURCE_PATH}" because ${WORKSPACE_SOURCE_PATH} might be "/"
+        # or the root of a mounted volume.
+        if [ -d "${WORKSPACE_SOURCE_PATH}" ] ; then
+          # Delete non-hidden files and directories
+          rm -rf "${WORKSPACE_SOURCE_PATH:?}"/*
+          # Delete files and directories starting with . but excluding ..
+          rm -rf "${WORKSPACE_SOURCE_PATH}"/.[!.]*
+          # Delete files and directories starting with .. plus any other character
+          rm -rf "${WORKSPACE_SOURCE_PATH}"/..?*
+        fi
+
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Task


### PR DESCRIPTION
This is the fix for #14 **BUG: git-clone permission denied removing cached files**. It should not be merged until all of the labs have been updated to reflect the new code.

### Problem Description

The `git-clone` Tekton task is hard-coded to run as user `65532`. Other tasks run as other users. When a task that causes a compile of the Python code runs, it leaves behind `*.pyc` files that are owned by that user. This works once! The second time the pipeline runs, the `git-clone` task tries to empty the directory but does not have the privilege to remove these files owner by another user. This fix adds a task before all others in the pipeline that removes all files as root. 

### Changes:

* Added a new `cleanup` Task to `tasks.yaml` to remove all files as root.
* Added a new `init` task to the Pipeline to be run before the `clone` task
* Modified the `clone` task to `runAfter` the `init` task

This seems to have fixed the issue. Perhaps a more permanent fix might be to get all of the tasks to run as the same user. We will investigate this for a future version.