### PR TITLE
Removed codecov

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ black==22.3.0
 nose==1.3.7
 pinocchio==0.4.3
 coverage==6.3.2
-codecov==2.1.12
 
 # Utilities
 httpie==3.2.1


### PR DESCRIPTION
Codecov.io delete their package from PyPi breaking builds all over the world. This PR removes this dependency.

closes #24 